### PR TITLE
api changes on exercise/api/serializer.py, exercise/api/views.py, wge…

### DIFF
--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -33,6 +33,14 @@ class ExerciseSerializer(serializers.ModelSerializer):
         model = Exercise
 
 
+class ExerciseInfoSerializer(serializers.ModelSerializer):
+    '''
+    Exercise info serializer
+    '''
+    class Meta:
+        model = Exercise
+
+
 class EquipmentSerializer(serializers.ModelSerializer):
     '''
     Equipment serializer

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -29,6 +29,7 @@ from wger.config.models import LanguageConfig
 from wger.exercises.api.serializers import (
     MuscleSerializer,
     ExerciseSerializer,
+    ExerciseInfoSerializer,
     ExerciseImageSerializer,
     ExerciseCategorySerializer,
     EquipmentSerializer,
@@ -77,6 +78,7 @@ class ExerciseViewSet(viewsets.ModelViewSet):
         obj.save()
 
 
+
 @api_view(['GET'])
 def search(request):
     '''
@@ -122,6 +124,28 @@ def search(request):
 
     return Response(json_response)
 
+
+
+class ExerciseInfoViewSet(viewsets.ModelViewSet):
+    '''
+    API endpoint for exercise info objects
+    '''
+    queryset = Exercise.objects.all()
+    serializer_class = ExerciseInfoSerializer
+    permission_classes = (IsAuthenticatedOrReadOnly, CreateOnlyPermission)
+    ordering_fields = '__all__'
+    filter_fields = ('category',
+                     'creation_date',
+                     'description',
+                     'language',
+                     'muscles',
+                     'muscles_secondary',
+                     'status',
+                     'name',
+                     'equipment',
+                     'license',
+                     'license_author')
+                     
 
 class EquipmentViewSet(viewsets.ReadOnlyModelViewSet):
     '''

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -103,6 +103,7 @@ router.register(r'setting-weightunit', core_api_views.WeightUnitViewSet, base_na
 
 # Exercises app
 router.register(r'exercise', exercises_api_views.ExerciseViewSet, base_name='exercise')
+router.register(r'exerciseinfo', exercises_api_views.ExerciseInfoViewSet, base_name='exerciseinfo')
 router.register(r'equipment', exercises_api_views.EquipmentViewSet, base_name='api')
 router.register(r'exercisecategory', exercises_api_views.ExerciseCategoryViewSet, base_name='exercisecategory')
 router.register(r'exerciseimage', exercises_api_views.ExerciseImageViewSet, base_name='exerciseimage')


### PR DESCRIPTION
***What does this PR do?***
Creates a new read-only API endpoint with all the information of an exercise such as muscles, category, images, etc. This is to make it easier for clients to get all the infos since only a single request is needed to be done

***Description of Task to be completed?***
> Creating a new read-only API endpoint that collects all the information of an exercise
> Creating a class for the new api on serializer
> Creating a new view set information exercise
> Registering the api route on the urls 

***How should this be manually tested?***
• Follow installation guide and run the app
• Go into the 'About this Software' tab and click on REST API.
• Click the link under REST API heading.
• Select the following link "exerciseinfo": "http://127.0.0.1:8000/api/v2/exerciseinfo/"
• Select a test and post it in the content field at the edit for section
• Make sure all the field are filled
• Click on POST
• You should receive the following message 'HTTP 201 Created'


*What are the relevant pivotal tracker stories?*
#144208783